### PR TITLE
feat(user-repository): Add UserRepository with common query methods

### DIFF
--- a/src/main/java/com/muscledia/user_service/user/repo/UserRepository.java
+++ b/src/main/java/com/muscledia/user_service/user/repo/UserRepository.java
@@ -1,0 +1,16 @@
+package com.muscledia.user_service.user.repo;
+
+import com.muscledia.user_service.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsByUsername(String username);
+
+    boolean existsByEmail(String email);
+}


### PR DESCRIPTION
### Summary

- Created `UserRepository` extending `JpaRepository<User, Long>`.
- Added methods to:
  - Find users by `username` or `email`.
  - Check existence of `username` or `email` (useful for validations).

These methods enable foundational CRUD and lookup logic for the user domain.