### PR TITLE
feat(avatar-repository): Add AvatarRepository

### DIFF
--- a/src/main/java/com/muscledia/user_service/avatar/repo/AvatarRepository.java
+++ b/src/main/java/com/muscledia/user_service/avatar/repo/AvatarRepository.java
@@ -1,0 +1,17 @@
+package com.muscledia.user_service.avatar.repo;
+
+import com.muscledia.user_service.avatar.entity.Avatar;
+import com.muscledia.user_service.avatar.entity.AvatarType;
+import com.muscledia.user_service.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AvatarRepository extends JpaRepository<Avatar, Long> {
+    Optional<Avatar> findByUser(User user);
+
+    boolean existsByUser(User user);
+
+    Optional<Avatar> findByAvatarType(AvatarType avatarType);
+
+}


### PR DESCRIPTION
This PR introduces the `AvatarRepository` interface for accessing and managing avatar data.

---

### Changes

- Created `AvatarRepository` extending `JpaRepository<Avatar, Long>`.
- Added:
  - `findByUser(User user)` – retrieve avatar for a specific user.
  - `existsByUser(User user)` – validate avatar existence for a user.
  - `findByAvatarType(AvatarType avatarType)` – retrieve avatar by type.
