### PR TITLE
Feature: Notification Repository

### DIFF
--- a/src/main/java/com/muscledia/user_service/notification/repo/NotificationRepository.java
+++ b/src/main/java/com/muscledia/user_service/notification/repo/NotificationRepository.java
@@ -1,0 +1,15 @@
+package com.muscledia.user_service.notification.repo;
+
+import com.muscledia.user_service.notification.entity.Notification;
+import com.muscledia.user_service.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByUser(User user);
+
+    List<Notification> findByUserAndIsReadFalse(User user);
+
+    long countByUserAndIsReadFalse(User user);
+}


### PR DESCRIPTION
This PR introduces the `NotificationRepository` interface for managing user notifications in the system.

---

### What's Included

- Created `NotificationRepository` extending `JpaRepository<Notification, Long>`.
- Added:
  - `findByUser(User user)` – retrieve all notifications for a user.
  - `findByUserAndIsReadFalse(User user)` – get only unread notifications.
  - `countByUserAndIsReadFalse(User user)` – count unread notifications for badge indicators.

---